### PR TITLE
Add support for multiple volume groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work
 # IDE files
 .idea
 libvirt-storage-attach
+publish.sh

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,9 @@ func main() {
 	var operation string
 	flag.StringVar(&operation, "operation", "", "attach, detach, create, delete")
 
+	var volumeGroup string
+	flag.StringVar(&volumeGroup, "volume-group", cfg.LvmVolumeGroup, "volume group name")
+
 	var pvId string
 	flag.StringVar(&pvId, "pv-id", "", "persistent volume id")
 
@@ -127,7 +130,7 @@ func main() {
 			Cfg:  cfg,
 			PvId: "",
 		}
-		pvId, err = c.CreateVolume(volumeSize)
+		pvId, err = c.CreateVolume(volumeSize, volumeGroup)
 		if len(pvId) > 0 {
 			fmt.Println(pvId)
 		}


### PR DESCRIPTION
Tries to use the passed in -volume-group arg on `create` otherwise defaults to config file

Looks up LV VG by listing all VG/LV pairs

Assumes PV name is unique across LVM Volume Groups (it should be unless it's manually been copied without renaming)